### PR TITLE
Fix popover and tooltip javscript to work when returning to homepage.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,16 +17,20 @@
 		  ga('send', 'pageview');
 	  </script>
 	  <script>
-		$(document).ready(function(){
-		    $('[data-toggle="popover"]').popover(); 
-		});
+                var ready = function() {
+        	    $('[data-toggle="popover"]').popover(); 
+		};
+		$(document).ready(ready);
+                $(document).on('page:load', ready);
 	  </script>
 
 	  <!--  tooltip -->
 	  <script>
-		$(document).ready(function(){
+                var ready = function(){
 		    $('[data-toggle="tooltip"]').tooltip(); 
-		});
+		};
+		$(document).ready(ready);
+                $(document).on('page:load', ready);
 	  </script>
 
 	  <!-- Ahoy Gem -->


### PR DESCRIPTION
Previously popover and tooltip failed because they would not run on pageload when returning to the homepage from a secondary page. Now the javascript runs both on document ready and pageload.