### PR TITLE
Add redis caching and rack attack.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Redis for caching 
+gem 'redis-rails'
+
 # Simple Captcha for signing up
 gem 'gotcha'
 
@@ -116,6 +119,12 @@ gem 'gmaps4rails'
 
 # implement elasticsearch
 gem 'searchkick'
+
+# Rack Attack for basic security through throttling and blocking
+gem 'rack-attack'
+
+# Rack Test for testing 
+gem 'rack-test', require: 'rack/test'
 
 # manage nested forms
 gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,6 +374,8 @@ GEM
     puma (2.11.2)
       rack (>= 1.1, < 2.0)
     rack (1.6.0)
+    rack-attack (4.3.0)
+      rack
     rack-pjax (0.8.0)
       nokogiri (~> 1.5)
       rack (~> 1.1)
@@ -427,6 +429,23 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rdoc (4.2.0)
+    redis (3.2.1)
+    redis-actionpack (4.0.0)
+      actionpack (~> 4)
+      redis-rack (~> 1.5.0)
+      redis-store (~> 1.1.0)
+    redis-activesupport (4.1.1)
+      activesupport (~> 4)
+      redis-store (~> 1.1.0)
+    redis-rack (1.5.0)
+      rack (~> 1.5)
+      redis-store (~> 1.1.0)
+    redis-rails (4.0.0)
+      redis-actionpack (~> 4)
+      redis-activesupport (~> 4)
+      redis-store (~> 1.1.0)
+    redis-store (1.1.6)
+      redis (>= 2.2)
     referer-parser (0.3.0)
     remotipart (1.2.1)
     request_store (1.1.0)
@@ -589,9 +608,12 @@ DEPENDENCIES
   pg
   pry-byebug
   puma
+  rack-attack
+  rack-test
   rails (= 4.2.1)
   rails_12factor
   rails_admin
+  redis-rails
   rollbar (~> 1.5.3)
   rspec-activemodel-mocks
   rspec-rails (~> 3.0)
@@ -609,3 +631,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   whenever
+
+BUNDLED WITH
+   1.10.5

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module Blackops
     # config.i18n.default_locale = :de
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
+
+    config.cache_store = :redis_store, ENV["REDISTOGO_URL"], { expires_in: 90.minutes }
     
     config.active_record.raise_in_transactional_callbacks = true
 
@@ -37,5 +39,8 @@ module Blackops
         :request_specs => true
       g.fixture_replacement :factory_girl, :dir => "spec/factories"
     end
+
+    config.middleware.use Rack::Attack
+
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,8 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
+  # Enable caching in development
+  config.action_controller.perform_caching = true
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_store 
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = 'd39r1dufm4jbqr.cloudfront.net'

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,0 +1,24 @@
+class Rack::Attack
+  
+  # Throttle all requests by IP (60rpm)
+  throttle('req/ip', limit: 20, period: 20.seconds) do |req|
+    req.ip unless req.path.starts_with? ('/assets')
+  end
+
+  # Throttle login attempts 
+  throttle('logins/ip', limit: 5, period: 20.seconds) do |req|
+    if req.path == '/users/sign_in' && req.post?
+      req.ip
+    end
+  end
+
+  # Throttle login attempts by email address
+  throttle('logins/email', limit: 5, period: 20.seconds) do |req|
+    if req.path == '/users/sign_in' && req.post?
+      req.params['email'].presence
+    end
+  end
+
+
+
+end

--- a/spec/config/initializers/rack-attack-spec.rb
+++ b/spec/config/initializers/rack-attack-spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe Rack::Attack do
+  include Rack::Test::Methods
+
+  def app
+    Rails.application  
+  end
+
+  describe "throttle excessive requests by IP address" do
+    let(:limit) { 20 }
+
+    context "number of requests is lower than the limit" do
+      it "does not change the request status" do
+        limit.times do
+          get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+          last_response.status.should_not be(429)
+        end
+      end
+    end
+
+    context "number of requests is higher than the limit" do
+      it "changes the request status 429" do
+        (limit * 2).times do |i|
+          get "/", {}, "REMOTE_ADDR" => "1.2.3.5"
+          last_response.status.should be(429) if i > limit
+        end
+      end
+    end
+
+  end
+
+  describe "throttle excessive POST requests to sign in by IP address" do
+    let(:limit) { 5 }
+
+    context "number of requests is lower than the limit" do
+      it "does not change the request status" do
+        limit.times do |i|
+          post "/users/sign_in", { email: "rack_attack_example3#{i}@gmail.com" }, "REMOTE_ADDR" => "1.2.3.6"
+          last_response.status.should_not be(429)
+        end
+      end
+    end
+
+    context "number of requests is higher than the limit" do
+      it "changes the request status to 429" do
+        (limit*2).times do |i|
+          post "/users/sign_in", { email: "rack_attack_example4#{i}@gmail.com" }, "REMOTE_ADDR" => "1.2.3.7"
+          last_response.status.should be(429) if i > limit
+        end
+      end
+    end
+
+  end
+
+  describe "throttle excessive POST requests to sign in by email address" do
+    let(:limit) { 5 }
+
+    context "number of requests is lower than limit" do
+      it "does not change the request status" do
+        limit.times do |i|
+          post "/users/sign_in", { email: "rack_attack_example5@gmail.com" }, "REMOTE_ADDR" => "#{i}.2.3.8"
+          last_response.status.should_not be(429)
+        end
+      end
+    end
+
+    context "number of requests is higher than the limit" do
+      it "changes the request status to 429" do
+        (limit*2).times do |i|
+          post "/users/sign_in", { email: "rack_attack_example6@gmail.com" }, "REMOTE_ADDR" => "#{i}.2.3.9"
+          last_response.status.should be(429) if i > limit
+        end
+      end
+    end
+
+  end
+
+end
+


### PR DESCRIPTION
Added redis caching and rack attack, including rspec tests. The tests won't pass unless ENV["REDISTOGO_URL"] is set to a redis server url in ".env" file for development.

Tested on staging. Before merging to heroku must add on redistogo with:

$ heroku addons:create redistogo

Will work after that.

