### PR TITLE
Adding basic authenticaion for Issue #183

### DIFF
--- a/config/initializers/split.rb
+++ b/config/initializers/split.rb
@@ -9,9 +9,9 @@ Split.configure do |config|
   config.enabled = !Rails.env.test?
 end
 
-# Split::Dashboard.use Rack::Auth::Basic do |username, password|
-#   username == 'fire_in' && password == 'the_hole' # This one is fake :P
-# end
+Split::Dashboard.use Rack::Auth::Basic do |username, password|
+  username == ENV["SPLIT_USERNAME"] && password == ENV["SPLIT_PASSWORD"]
+end
 
 if ENV["REDISTOGO_URL"]
    uri = URI.parse(ENV["REDISTOGO_URL"])


### PR DESCRIPTION
Basic authentication prevents unauthorized users from accessing our A/B
tests and potentially altering the tests or results.

However, ultimately we should be looking for a better solution --
either by creating a subroute within the rails_admin panel or using
Pundit or CanCanCan for more robust authorizations