### PR TITLE
Re-branched from master to add authentication for #183

### DIFF
--- a/config/initializers/split.rb
+++ b/config/initializers/split.rb
@@ -9,9 +9,9 @@ Split.configure do |config|
   config.enabled = !Rails.env.test?
 end
 
-Split::Dashboard.use Rack::Auth::Basic do |username, password|
-  username == ENV["SPLIT_USERNAME"] && password == ENV["SPLIT_PASSWORD"]
-end
+# Split::Dashboard.use Rack::Auth::Basic do |username, password|
+#   username == ENV["SPLIT_USERNAME"] && password == ENV["SPLIT_PASSWORD"]
+# end
 
 if ENV["REDISTOGO_URL"]
    uri = URI.parse(ENV["REDISTOGO_URL"])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,12 @@ Rails.application.routes.draw do
     resources :registrations
   end
 
-  mount Split::Dashboard, at: 'split'
+  mount Split::Dashboard, at: 'split', :anchor => false, :constraints => lambda { |request|
+    request.env['warden'].authenticated? # are we authenticated?
+    request.env['warden'].authenticate! # authenticate if not already
+    # or even check any other condition
+    request.env['warden'].user.admin?
+  }
 
   # mailbox folder routes
   get "mailbox", to: redirect("mailbox/inbox")

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -13,6 +13,8 @@ require 'rails_helper'
         expect(page).to have_content "Invalid email or password"
         visit rails_admin.dashboard_path
         expect(page).to have_content "You are not an admin"
+        visit split_dashboard_path
+        expect(page).to have_content "You need to sign in or sign up before continuing"
       end
     end
 
@@ -45,6 +47,8 @@ require 'rails_helper'
         expect(page).to have_content "Invalid email or password"
         visit rails_admin.dashboard_path
         expect(page).to have_content "You are not an admin"
+        visit split_dashboard_path
+        expect(page).to have_content "You need to sign in or sign up before continuing"
       end
 
     end
@@ -65,6 +69,8 @@ require 'rails_helper'
         click_button 'Log in'
         visit rails_admin.dashboard_path
         expect(page).to have_content "Site Administration"
+        visit split_dashboard_path
+        expect(page).to have_content "Split Dashboard"
       end
 
       # This is a failure feature spec; this covers the scenario


### PR DESCRIPTION
also added to existing admin specs to confirm that the correct pages are
shown when the user is not logged in or is logged in as an admin user.
ultimately, we need to more gracefully handle non-admin users in this
case, but i don't think that should hold us up from pushing to
production.