### PR TITLE
for #674 fixes and additions to sitemap config file

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -5,27 +5,38 @@ SitemapGenerator::Sitemap.default_host = "http://ebwiki.org"
 SitemapGenerator::Sitemap.public_path = 'tmp/'
 
 SitemapGenerator::Sitemap.sitemaps_path = 'sitemaps/'
+SitemapGenerator::Sitemap.create_index = true
 
-# if Rails.env.production?
+if Rails.env.production?
 # Instance of `SitemapGenerator::s3Adapter -- could have used wave adapter instead
-SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
-  fog_provider: 'AWS', 
-  aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-  aws_secret_access_key: ENV['AWS_SECRET_KEY_ID'],
-  fog_directory: ENV['FOG_DIRECTORY'],
-  fog_region: ENV['S3_REGION'])
+  SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
+    fog_provider: 'AWS',
+    aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+    aws_secret_access_key: ENV['AWS_SECRET_KEY_ID'],
+    fog_directory: ENV['FOG_DIRECTORY'],
+    fog_region: ENV['S3_REGION'])
 
- # The remote host where your sitemaps will be hosted
- SitemapGenerator::Sitemap.sitemaps_host = "http://#{ENV['FOG_DIRECTORY']}.s3.amazonaws.com/"
-# end
+# The remote host where your sitemaps will be hosted
+  SitemapGenerator::Sitemap.sitemaps_host = "http://#{ENV['FOG_DIRECTORY']}.s3.amazonaws.com/"
+end
 
 SitemapGenerator::Sitemap.create do
   # Add all articles:
 
   Article.find_each do |article|
-    add article_path(article), :lastmod => article.updated_at 
+    add article_path(article), :lastmod => article.updated_at
     add articles_followers_path(article), :lastmod => article.updated_at
   end
+end
+
+SitemapGenerator::Sitemap.filename = 'agencies'
+SitemapGenerator::Sitemap.create do
+  # Add all agencies:
+
+  Agency.find_each do |agency|
+    add agency_path(agency), :lastmod => agency.updated_at
+  end
+
   # Put links creation logic here.
   #
   # The root path '/' and sitemap index file are added automatically for you.


### PR DESCRIPTION
I just rebased this branch.  We now have several hundred agency pages that we could get indexed for search. I think this makes sense to do. I believe I have done this correctly to create a separate sitemap for agencies, but want code review before merging. Previous commit message below:

I didn't want to push this without checking in with @trystant first.
This branch contains the following changes to the sitemap config:

1. Added a line to create_index within the sitemap which causes an index
file to be created to reference multiple sitemaps

2. Added back the conditional to store sitemaps only if env==production.
Not sure why we had commented that out.

3. Added a second generator to create another sitemap with the filename
'agencies' to house urls for the agency show pages. I added the filename
so not to overwrite our current urls

In the end, though I think we want to include this new content in this
way, I decided not to push because of the small number of agencies we
have, the fact that search engines will eventually find them organically
since they are all the subject of internal links and because I don't
want to negatively affect our growing presence in search results.