### PR TITLE
Adding scheduled task to clean backups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,3 +172,6 @@ gem 'ckeditor', :git => 'https://github.com/galetahub/ckeditor.git'
 
 # New Relic performance monitor
 gem 'newrelic_rpm'
+
+# for HTTParty
+gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,6 +349,9 @@ GEM
     hodel_3000_compliant_logger (0.1.1)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
+    httparty (0.13.5)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     image_optimizer (1.3.0)
     inflecto (0.0.2)
@@ -401,6 +404,7 @@ GEM
       railties (>= 3.1)
     multi_json (1.12.1)
     multi_test (0.1.2)
+    multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.3.0)
     nested_form (0.3.2)
@@ -665,6 +669,7 @@ DEPENDENCIES
   guard-rspec
   heroku_rails_deflate
   hightop
+  httparty
   jbuilder (~> 2.0)
   jquery-rails
   jquery-turbolinks

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -7,6 +7,12 @@ every 1.day, :at => '5:00 am' do
 	end
 end
 
+# preserve storage capacity by deleting oldest snapshot
+every 1.day, :at => '5:15 am' do
+  if Rails.env.production?
+    rake "autobus_cleanup"
+  end
+end
 #
 # It's helpful, but not entirely necessary to understand cron before proceeding.
 # http://en.wikipedia.org/wiki/Cron

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -174,10 +174,11 @@ if Ethnicity.count == 0
     [ "White" ],
     [ "Hispanic" ],
     [ "Native American" ],
-    [ "Asian" ]
+    [ "Asian" ],
+    [ "Arabic" ]
   ]
 
   ethnicities.each do |ethnicity|
-    Ethnicity.create( :sex => ethnicity[0])
+    Ethnicity.create( :title => ethnicity[0])
   end
 end

--- a/lib/tasks/autobus_cleanup.rake
+++ b/lib/tasks/autobus_cleanup.rake
@@ -1,0 +1,27 @@
+desc "Destroy old Autobus backups"
+task :autobus_cleanup => :environment do
+  p "Autobus Cleanup started!"
+
+  # retrieve autobus backups
+  backups = HTTParty.get("https://www.autobus.io/api/snapshots?token=#{ENV['AUTOBUS_ACCESS_TOKEN']}")
+  p "Retrieved #{backups.size} backups!"
+
+  # count total memory used by existing snapshots
+  total_storage = 0
+  backups.each do |snap|
+    total_storage += snap["size"]
+  end
+
+  # if total memory used is over 99% of capacity, delete the last snapshot
+  max_storage = 10000000000 #10gb limit on current plan
+  while total_storage > (max_storage * 99 / 100)
+    memory_2_b_freed = backups.last["size"]
+
+    snap_to_drop_id = backups.last["id"]
+    backups.delete_if { |h| h["id"] == snap_to_drop_id }
+    HTTParty.delete("https://www.autobus.io/api/snapshots/#{snap_to_drop_id}?token=#{ENV['AUTOBUS_ACCESS_TOKEN']}")
+    p "The oldest snapshot has been deleted!"
+    total_storage -= memory_2_b_freed
+  end
+  p "We've got plenty of room now. No need to destroy anything!"
+end


### PR DESCRIPTION
This task basically takes our current Autobus storage limit of 10gb and
compares that to the total size of all of our backup snapshots. If we
are over the limit, the task will delete the oldest snapshot until we
are back under the limit.

This will likely not be an issue for several months, but we are being
proactive.