### PR TITLE
Geocoding Improvements

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -48,7 +48,7 @@ class Article < ActiveRecord::Base
   # Geocoding
   geocoded_by :full_address
   before_save :geocode, if: Proc.new {|art| 
-    art.address_changed? || art.city_changed? || art.state_changed? || art.zipcode_changed?
+    art.address_changed? || art.city_changed? || art.state_id_changed? || art.zipcode_changed?
   } # auto-fetch coordinates
   
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -43,10 +43,14 @@ class Article < ActiveRecord::Base
   # Avatar uploader using carrierwave
   mount_uploader :avatar, AvatarUploader
 
-  # Geocoding articles
-  geocoded_by :full_address   # can also be an IP address
   # before_validation :check_for_empty_fields
-  after_validation :geocode          # auto-fetch coordinates
+  
+  # Geocoding
+  geocoded_by :full_address
+  before_save :geocode, if: Proc.new {|art| 
+    art.address_changed? || art.city_changed? || art.state_changed? || art.zipcode_changed?
+  } # auto-fetch coordinates
+  
 
 
   # Scopes
@@ -54,7 +58,7 @@ class Article < ActiveRecord::Base
   scope :property_count_over_time, -> (property, days) { where( "#{property}": "#{days}".to_i.days.ago..Time.now).count }
 
   def full_address
-    "#{address} #{city} #{state.ansi_code} #{zipcode}"
+    "#{address} #{city} #{state.ansi_code} #{zipcode}".strip
   end
 
   def self.find_by_search(query)

--- a/db/migrate/20170519002221_add_lat_lng_to_agencies.rb
+++ b/db/migrate/20170519002221_add_lat_lng_to_agencies.rb
@@ -1,0 +1,6 @@
+class AddLatLngToAgencies < ActiveRecord::Migration
+  def change
+    add_column :agencies, :longitude, :float
+    add_column :agencies, :latitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160708194753) do
+ActiveRecord::Schema.define(version: 20170519002221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,10 +27,11 @@ ActiveRecord::Schema.define(version: 20160708194753) do
     t.string   "email"
     t.string   "website"
     t.string   "lead_officer"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
     t.string   "slug"
-    t.integer  "follows_count",  default: 0, null: false
+    t.float    "longitude"
+    t.float    "latitude"
   end
 
   create_table "ahoy_events", id: :uuid, default: nil, force: :cascade do |t|
@@ -84,7 +85,6 @@ ActiveRecord::Schema.define(version: 20160708194753) do
     t.boolean  "remove_avatar"
     t.text     "summary"
     t.integer  "follows_count",    default: 0, null: false
-    t.json     "documents"
   end
 
   add_index "articles", ["slug"], name: "index_articles_on_slug", unique: true, using: :btree
@@ -106,13 +106,6 @@ ActiveRecord::Schema.define(version: 20160708194753) do
   end
 
   add_index "comments", ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type", using: :btree
-
-  create_table "documents", force: :cascade do |t|
-    t.string   "name"
-    t.string   "attachment"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "ethnicities", force: :cascade do |t|
     t.string   "title"
@@ -268,7 +261,6 @@ ActiveRecord::Schema.define(version: 20160708194753) do
     t.boolean  "admin",                  default: false
     t.float    "latitude"
     t.float    "longitude"
-    t.string   "storytime_name"
     t.string   "name"
     t.text     "description"
     t.integer  "state_id"

--- a/lib/tasks/geocode_data.rake
+++ b/lib/tasks/geocode_data.rake
@@ -1,0 +1,30 @@
+# To run:
+# rake geocode:all CLASS=YourModel SLEEP=0.25 BATCH=100
+
+namespace :geocode_data do
+  desc "Geocode all objects without coordinates."
+  task :all => :environment do
+    class_name = ENV['CLASS'] || ENV['class']
+    sleep_timer = ENV['SLEEP'] || ENV['sleep']
+    raise "Please specify a CLASS (model)" unless class_name
+    klass = class_from_string(class_name)
+
+    klass.not_geocoded.find_each(batch_size: 100) do |obj|
+      obj.geocode; obj.save
+      sleep(sleep_timer.to_f) unless sleep_timer.nil?
+    end
+  end
+end
+
+##
+# Get a class object from the string given in the shell environment.
+# Similar to ActiveSupport's +constantize+ method.
+#
+def class_from_string(class_name)
+  parts = class_name.split("::")
+  constant = Object
+  parts.each do |part|
+    constant = constant.const_get(part)
+  end
+  constant
+end

--- a/lib/tasks/geocode_data.rake
+++ b/lib/tasks/geocode_data.rake
@@ -1,5 +1,5 @@
 # To run:
-# rake geocode:all CLASS=YourModel SLEEP=0.25 BATCH=100
+# rake geocode_data:all CLASS=YourModel SLEEP=0.25 BATCH=100
 
 namespace :geocode_data do
   desc "Geocode all objects without coordinates."

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ArticlesController, type: :controller do
       let(:subject_attrs) { FactoryGirl.attributes_for(:subject) }
 
       it 'success' do
-        allow_any_instance_of(Article).to receive(:full_address).and_return(" Albany NY ")
+        allow_any_instance_of(Article).to receive(:full_address).and_return("Albany NY")
         article_attrs['subjects_attributes'] = {"0" => subject_attrs}
 
         post :create, {'article': article_attrs }
@@ -77,7 +77,7 @@ RSpec.describe ArticlesController, type: :controller do
       end
 
       it 'saves and assigns new article to @article' do
-        allow_any_instance_of(Article).to receive(:full_address).and_return(" Albany NY ")
+        allow_any_instance_of(Article).to receive(:full_address).and_return("Albany NY")
         article_attrs['subjects_attributes'] = {"0" => subject_attrs}
         post :create, {'article': article_attrs }
         expect(assigns(:article)).to be_a_kind_of(Article)

--- a/spec/controllers/maps_controller_spec.rb
+++ b/spec/controllers/maps_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MapsController, type: :controller do
   describe "GET #index" do
     
   	let!(:articles) {
-  	  allow_any_instance_of(Article).to receive(:full_address).and_return("230 West 43rd St., New York City, NY 10036")
+  	  allow_any_instance_of(Article).to receive(:full_address).and_return("230 West 43rd St. New York City NY 10036")
   	  FactoryGirl.create_list(:article, 20) 
   	  
   	} 

--- a/spec/factories/agencies.rb
+++ b/spec/factories/agencies.rb
@@ -1,15 +1,15 @@
 FactoryGirl.define do
-  factory :agency do
-    name "MyString"
-    street_address "MyString"
-    city "MyString"
-    state_id 1
-    zipcode "MyString"
-    description "MyText"
-    telephone "MyString"
-    email "MyString"
-    website "MyString"
-    lead_officer "MyString"
+  factory :agency do |f|
+    f.name "MyAgency"
+    f.street_address "230 West 43rd St."
+    f.city "New York City"
+    f.state
+    f.zipcode "10036"
+    f.description "MyText"
+    f.telephone "MyString"
+    f.email "MyString"
+    f.website "MyString"
+    f.lead_officer "MyString"
   end
 
   factory :invalid_agency, class: Agency do |f|

--- a/spec/factories/state.rb
+++ b/spec/factories/state.rb
@@ -1,8 +1,15 @@
 # This will guess the Article class
 FactoryGirl.define do
+  sequence(:id)
   factory :state do |f|
+    f.id
     f.name "New York"
-    f.sequence(:id)
     f.ansi_code "NY"
+  end
+  factory :state_ohio, :class => State do |f|
+    f.id
+    f.name "Ohio"
+    f.ansi_code "OH"
+    f.iso 'US-OH'
   end
 end

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -18,12 +18,32 @@ RSpec.describe Agency, type: :model do
     expect(agency2).to be_invalid
   end
 
-  it 'updates slug if article title is updated' do
+  it 'updates slug if agency title is updated' do
     agency = FactoryGirl.create(:agency, name: "The Title")
     agency.slug = nil
     agency.name = "Another Title"
     agency.save!
     agency.reload
     expect(agency.slug).to eq "another-title"
+  end
+  
+  describe "geocoded" do
+    it "generates longitude and latitude from city and state on save" do
+      agency = FactoryGirl.create(:agency)
+      expect(agency.latitude).to be_a(Float)
+      expect(agency.longitude).to be_a(Float)
+    end
+    
+    it "updates geocoded coordinates when relevant fields are updated" do
+      agency = FactoryGirl.create(:agency)
+      ohio = FactoryGirl.create(:state_ohio)
+      
+      expect{ agency.update_attributes({
+        city: "Worthington", 
+        state_id: ohio.id, 
+        street_address: "1867 Irving Road", 
+        zipcode: '43085'
+      })}.to change{ agency.latitude }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -45,7 +45,7 @@ describe Article, :versioning => true do
   end
   it 'adds a version when the city is changed' do
     article = FactoryGirl.create(:article)
-    article.update_attribute(:city, "New Jack City")
+    article.update_attribute(:city, "Buffalo")
     expect(article.versions.size).to eq 2
   end
   it 'adds a version when the avatar is changed' do
@@ -133,13 +133,22 @@ describe "#content" do
 end
 
 describe "geocoded" do
-  it "has a latitude" do
+  it "generates longitude and latitude from city and state on save" do
     article = FactoryGirl.create(:article)
-      expect(article.latitude).not_to be_nil
+    expect(article.latitude).to be_a(Float)
+    expect(article.longitude).to be_a(Float)
   end
-  it "has a longitude" do
+  
+  it "updates geocoded coordinates when relevant fields are updated" do
     article = FactoryGirl.create(:article)
-      expect(article.longitude).not_to be_nil
+    ohio = FactoryGirl.create(:state_ohio)
+    
+    expect{ article.update_attributes({
+      city: "Worthington", 
+      state_id: ohio.id, 
+      address: "1867 Irving Road", 
+      zipcode: '43085'
+    })}.to change{ article.latitude }
   end
 end
 

--- a/spec/support/geocoder.rb
+++ b/spec/support/geocoder.rb
@@ -1,5 +1,14 @@
 addresses = {
-  "230 West 43rd St., New York City, NY 10036" => {
+  "New York City NY" => {
+      'latitude' => 40.7573862,
+      'longitude' => -73.9881256,
+      'address' => '230 West 43rd St.',
+      'city' => 'New York City',
+      'state' => 'New York',
+      'state_code' => 'NY',
+      'country' => 'United States',
+      'country_code' => 'US'
+  },"230 West 43rd St. New York City NY 10036" => {
       'latitude' => 40.7573862,
       'longitude' => -73.9881256,
       'address' => '230 West 43rd St., New York City, NY 10036',
@@ -19,7 +28,7 @@ addresses = {
       'country' => 'United States',
       'country_code' => 'US'
   },
-  "Worthington, OH" => {
+  "1867 Irving Road Worthington OH 43085" => {
     'latitude' => 40.09846115112305,
     'longitude' => -83.01747131347656,
     'address' => 'Worthington, OH',
@@ -29,7 +38,7 @@ addresses = {
     'country' => 'United States',
     'country_code' => 'US'
   },
-  " Albany NY " => {
+  "Albany NY" => {
     'latitude' => 42.6525793,
     'longitude' => -73.7562317,
     'address' => 'Albany, NY',
@@ -39,7 +48,7 @@ addresses = {
     'country' => 'United States',
     'country_code' => 'US'
   },
-    "  NY " => {
+    "NY" => {
     'latitude' => 42.6525793,
     'longitude' => -73.7562317,
     'address' => 'Albany, NY',
@@ -49,7 +58,7 @@ addresses = {
     'country' => 'United States',
     'country_code' => 'US'
   },
-    " Buffalo NY " => {
+    "Buffalo NY" => {
     'latitude' => 42.6525793,
     'longitude' => -73.7562317,
     'address' => 'Albany, NY',


### PR DESCRIPTION
This was written to resolve issue #881 and #834 .

Adds a slight modification of the rake task from the geocoder docs for the back-generation of article coordinates. The command is to run that is:
`rake geocode_data:all CLASS=Model SLEEP=0.25 BATCH=100`