### PR TITLE
Refactors functionality for adding users to mailchimp

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,4 +32,21 @@ class User < ActiveRecord::Base
     ]
   end
 
+  def mailchimp_status
+    if mailchimp_user.is_a?(Array)
+      nil
+    elsif mailchimp_user.is_a?(Hash)
+      mailchimp_user['status']
+    end
+  end
+
+  private
+
+  def mailchimp_user
+    gb = Gibbon::Request.new
+    gb.lists(ENV['MAILCHIMP_LIST_ID']).members(Digest::MDT.hexdigest(email.downcase.to_s)).retrieve)
+  rescue Gibbon::MailChimpError => e 
+    return nil, flash: { error: e.message }
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ActiveRecord::Base
 
   def mailchimp_user
     gb = Gibbon::Request.new
-    gb.lists(ENV['MAILCHIMP_LIST_ID']).members(Digest::MDT.hexdigest(email.downcase.to_s)).retrieve
+    gb.lists(ENV['MAILCHIMP_LIST_ID']).members(Digest::MD5.hexdigest(email.downcase.to_s)).retrieve
   rescue Gibbon::MailChimpError => e 
     return nil, flash: { error: e.message }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,8 +16,7 @@ class User < ActiveRecord::Base
   acts_as_messageable
   extend FriendlyId
   friendly_id :slug_candidates, use: %i[slugged finders]
-  after_save :add_to_mailchimp, on: [:create]
-
+  
   def mailboxer_name
     name
   end
@@ -33,37 +32,4 @@ class User < ActiveRecord::Base
     ]
   end
 
-  def add_to_mailchimp
-    if self[subscribed]
-      gb = Gibbon::Request.new
-      gb.lists.subscribe(id: ENV['MAILCHIMP_LIST_ID'], email: { email: email.to_s }, merge_vars: { FNAME: name.to_s })
-    end
-  end
-
-  # -------- Previous code
-  # returns the mailchimp member if one exists for @user.email
-  def mailchimp_user
-    gb = Gibbon::Request.new
-    gb.lists(ENV['MAILCHIMP_LIST_ID']).members(Digest::MD5.hexdigest(email.downcase.to_s)).retrieve
-  rescue Gibbon::MailChimpError => e
-    return nil, flash: { error: e.message }
-  end
-
-  # returns mailchimp member id for users registered with MC
-  def mailchimp_member_id
-    if mailchimp_user.is_a?(Array)
-      nil
-    elsif mailchimp_user.is_a?(Hash)
-      mailchimp_user['id']
-    end
-  end
-
-  # # returns the mailChimp status of the user
-  def mailchimp_status
-    if mailchimp_user.is_a?(Array)
-      nil
-    elsif mailchimp_user.is_a?(Hash)
-      mailchimp_user['status']
-    end
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ActiveRecord::Base
 
   def mailchimp_user
     gb = Gibbon::Request.new
-    gb.lists(ENV['MAILCHIMP_LIST_ID']).members(Digest::MDT.hexdigest(email.downcase.to_s)).retrieve)
+    gb.lists(ENV['MAILCHIMP_LIST_ID']).members(Digest::MDT.hexdigest(email.downcase.to_s)).retrieve
   rescue Gibbon::MailChimpError => e 
     return nil, flash: { error: e.message }
   end

--- a/app/models/user_observer.rb
+++ b/app/models/user_observer.rb
@@ -4,6 +4,7 @@ class UserObserver < ActiveRecord::Observer
   observe :user
 
   def after_create(user)
+  	AddUserToMailchimp.call(user)
     UserNotifier.welcome_email(user).deliver_now
   end
 end

--- a/app/services/add_user_to_mailchimp.rb
+++ b/app/services/add_user_to_mailchimp.rb
@@ -1,0 +1,13 @@
+class AddUserToMailchimp
+	include Service
+
+  def call(user)
+    if user.subscribed
+      gb = Gibbon::Request.new
+      gb.lists.subscribe({ :id => ENV['MAILCHIMP_LIST_ID'],
+                           :email => { :email => "#{user.email}"},
+                           :merge_vars => { :FNAME => "#{user.name}" } })
+    end
+  end
+
+end

--- a/app/services/service.rb
+++ b/app/services/service.rb
@@ -1,0 +1,9 @@
+module Service
+	extend ActiveSupport::Concern
+
+	included do
+		def self.call(*args)
+      new.call(*args)
+    end
+  end
+end

--- a/app/views/user_notifier/welcome_email.html.erb
+++ b/app/views/user_notifier/welcome_email.html.erb
@@ -1,6 +1,6 @@
 <h1>Welcome <%= @user.name %>!</h1>
 <p>Thanks for joining the EBWiki project. Our number one goal is to help you to stay on top of any developments in these cases.
-  <% if @user.subscribed %>
+  <% if @user[subscribed]? %>
     As a newsletter subscriber, you'll receive our general updates periodically.
     <% if @user.all_following.count <= 0 %>
       Likewise, it is very important that you click to follow specific cases and allow us to keep you up to date. The more people paying attention, the easier it will be effect change.</p>

--- a/app/views/user_notifier/welcome_email.html.erb
+++ b/app/views/user_notifier/welcome_email.html.erb
@@ -1,6 +1,6 @@
 <h1>Welcome <%= @user.name %>!</h1>
 <p>Thanks for joining the EBWiki project. Our number one goal is to help you to stay on top of any developments in these cases.
-  <% if @user[subscribed]? %>
+  <% if @user.subscribed? %>
     As a newsletter subscriber, you'll receive our general updates periodically.
     <% if @user.all_following.count <= 0 %>
       Likewise, it is very important that you click to follow specific cases and allow us to keep you up to date. The more people paying attention, the easier it will be effect change.</p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -186,3 +186,14 @@ if Ethnicity.count.zero?
     Ethnicity.create(title: ethnicity[0])
   end
 end
+
+if User.count == 0
+    puts "Creating Users..."
+
+    user_one = { name: "John Doe",
+                 email: "jdoe@example.com",
+                 password: "password",
+                 password_confirmation: "password"}
+                 
+    User.create(user_one)
+end


### PR DESCRIPTION
Refactors functionality for adding users to mailchimp as a service object.  By doing so, this should resolve the issues of accessing the subscribed value for a user in multiple places.

This code will unblock work for Issue #1003.